### PR TITLE
Fixes and Improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "caesar_cipher",
+    "name": "caesar_cipher_in_ICP",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/src/cipher.ts
+++ b/src/cipher.ts
@@ -9,7 +9,7 @@ export function encryptCaesar(text: string, shift: number): string {
     if (/[a-zA-Z]/.test(char)) {
       const isUpperCase = char === char.toUpperCase();
       const offset = isUpperCase ? 65 : 97;
-      const encryptedChar = String.fromCharCode((char.charCodeAt(0) - offset + shift) % 26 + offset);
+      const encryptedChar = String.fromCharCode((char.charCodeAt(0) + shift - offset) % 26 + offset);
       result += isUpperCase ? encryptedChar : encryptedChar.toLowerCase();
     } else {
       // If the character is not a letter, leave it unchanged
@@ -21,6 +21,7 @@ export function encryptCaesar(text: string, shift: number): string {
 
 // Function to decrypt a given text using the Caesar Cipher
 export function decryptCaesar(text: string, shift: number): string {
-  // To decrypt, we use a negative shift
-  return encryptCaesar(text, -shift);
+  // To decrypt, we substract the total number of alphabets(26) with the shift argument
+  // and call the encryptCaesar function with the new value
+  return encryptCaesar(text, 26 - shift);
 }

--- a/src/index.did
+++ b/src/index.did
@@ -1,4 +1,4 @@
 service: () -> {
-    Decrypt: (text, text) -> (text) query;
-    Encrypt: (text, text) -> (text) query;
+    Decrypt: (text, nat8) -> (variant {Ok:text; Err:text}) query;
+    Encrypt: (text, nat8) -> (variant {Ok:text; Err:text}) query;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,23 @@
-import { Canister, query, text } from 'azle';
+import { Canister, query, text, Result, Ok, Err, nat8 } from 'azle';
 import * as cipher from './cipher';
 
 const CaesarCipher = Canister({
   // Custom Caesar Cipher functions
 
   // calling the encrypt function
-  Encrypt : query([text, text], text, (text, shift) => {
-    const shiftInt = parseInt(shift);
-    if (isNaN(shiftInt)) {
-      throw new Error('Shift parameter must be a valid integer');
+  Encrypt : query([text, nat8], Result(text, text), (text, shift) => {
+    if (shift == 0 || shift > 25) {
+      return Err('Shift parameter must be a valid integer');
     }
-    return cipher.encryptCaesar(text, shiftInt);
+    return Ok(cipher.encryptCaesar(text, shift));
   }),
 
   // calling the decrypt function
-  Decrypt: query([text, text], text, (text, shift) => {
-    const shiftInt = parseInt(shift);
-    if (isNaN(shiftInt)) {
-      throw new Error('Shift parameter must be a valid integer');
+  Decrypt: query([text, nat8], Result(text, text), (text, shift) => {
+    if (shift == 0 || shift > 25) {
+      return Err('Shift parameter must be a valid integer');
     }
-    return cipher.decryptCaesar(text, shiftInt);
+    return Ok(cipher.decryptCaesar(text, shift));
   }),
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const CaesarCipher = Canister({
   // calling the encrypt function
   Encrypt : query([text, nat8], Result(text, text), (text, shift) => {
     if (shift == 0 || shift > 25) {
-      return Err('Shift parameter must be a valid integer');
+      return Err('Shift arugment must be between 1 and 25');
     }
     return Ok(cipher.encryptCaesar(text, shift));
   }),
@@ -15,7 +15,7 @@ const CaesarCipher = Canister({
   // calling the decrypt function
   Decrypt: query([text, nat8], Result(text, text), (text, shift) => {
     if (shift == 0 || shift > 25) {
-      return Err('Shift parameter must be a valid integer');
+      return Err('Shift arugment must be between 1 and 25');
     }
     return Ok(cipher.decryptCaesar(text, shift));
   }),


### PR DESCRIPTION
## Fixes and Improvements

1. Improved the input validation checks performed on the shift arguments to ensure that it is in the range of 1 and 25(0 and 26 return the same value as the **text** input argument) as there are only 26 alphabets and using values greater than 37 for the shift arguments leads to the decrypt function to fail and return an incorrect decrypt text. For example, by calling the Encrypt function with the input arguments of (text: test, shift: 38), the string **fqef** is returned. Using this returned value to call the Decrypt function along with the same shift value(38), the string **zeyz** is returned.
2. Improved the error response and returned values of the Encrypt and Decrypt function to ensure that an Ok response is returned in case of a successful function call and an Err value is returned if something went wrong instead of using panics when those situations can be handled with the Err type
3. Fixed bug in the operation `String.fromCharCode((char.charCodeAt(0) - offset + shift) % 26 + offset)` where this would result in unexpected issues with decrypting the encrypted cipher text using the same shift value used to encrypt. It is worth noting that the correct formula is this: `String.fromCharCode((char.charCodeAt(0) + shift - offset) % 26 + offset)` 
4. Fixed bug in the decryptCaesar function where you're required to subtract 26 with the shift argument and then use it in the encryptCaesar function.